### PR TITLE
Update libmp4v2

### DIFF
--- a/io.github.cmus.cmus.yml
+++ b/io.github.cmus.cmus.yml
@@ -43,8 +43,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/TechSmith/mp4v2/archive/Release-ThirdParty-MP4v2-4.1.3.tar.gz
-        sha512: 6cb63997ae7a162f91f11872f5a42e10305cf57fe52989650c8817daab94f079518668f408719d2df4e64047987679e3d82a5dd202ea69cc9fe4b7b5c84fbe11
+        url: https://github.com/TechSmith/mp4v2/archive/Release-ThirdParty-MP4v2-4.1.5.tar.gz
+        sha512: 593071e3e2d48a7bc704d4b32b28de300363d797236cf8904b3c403758fa08fcd9c0a1ebafc462f69d3964493515eeb391e23d5e27366e06c8d65f68c936b65a
       - type: patch
         path: libmp4v2-gcc7.patch
       - type: patch


### PR DESCRIPTION
Now at v4.1.5, only relevant change is apparently "allow parsing of some atoms to be skipped".