### PR TITLE
Revert mp4v2, also explicitly specify features during compilation

### DIFF
--- a/io.github.cmus.cmus.yml
+++ b/io.github.cmus.cmus.yml
@@ -43,8 +43,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/TechSmith/mp4v2/archive/Release-ThirdParty-MP4v2-4.1.5.tar.gz
-        sha512: 593071e3e2d48a7bc704d4b32b28de300363d797236cf8904b3c403758fa08fcd9c0a1ebafc462f69d3964493515eeb391e23d5e27366e06c8d65f68c936b65a
+        url: https://github.com/TechSmith/mp4v2/archive/Release-ThirdParty-MP4v2-4.1.3.tar.gz
+        sha512: 6cb63997ae7a162f91f11872f5a42e10305cf57fe52989650c8817daab94f079518668f408719d2df4e64047987679e3d82a5dd202ea69cc9fe4b7b5c84fbe11
       - type: patch
         path: libmp4v2-gcc7.patch
       - type: patch
@@ -118,6 +118,23 @@ modules:
   - name: cmus
     cleanup:
       - /share/man
+    build-options:
+      env: # Explicitly specify features so they don't just get disabled silently
+        - CONFIG_AAC=y
+        - CONFIG_CUE=y
+        - CONFIG_FFMPEG=y
+        - CONFIG_FLAC=y
+        - CONFIG_MAD=y
+        - CONFIG_MODPLUG=y
+        - CONFIG_MP4=y
+        - CONFIG_MPC=y
+        - CONFIG_MPRIS=y
+        - CONFIG_OPUS=y
+        - CONFIG_PULSE=y
+        - CONFIG_SAMPLERATE=y
+        - CONFIG_VORBIS=y
+        - CONFIG_WAV=y
+        - CONFIG_WAVPACK=y
     post-install:
       - install -Dm644 cmus.desktop /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 cmus.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg


### PR DESCRIPTION
v4.1.4 and 4.1.5 of mp4v2 no longer compiles with cmus as their header now assumes C++ while cmus is assuming C, so revert back to v4.1.3 for now. Also, the features are now explicitly set during compilation to prevent these sorts of issues from slipping through unnoticed.