### PR TITLE
Update to 2.9.1

### DIFF
--- a/io.github.cmus.cmus.metainfo.xml
+++ b/io.github.cmus.cmus.metainfo.xml
@@ -23,6 +23,8 @@
     <url type="homepage">https://cmus.github.io/</url>
 
     <releases>
+        <release version="2.9.1" date="2021-01-23"/>
+        <release version="2.9.0" date="2021-01-17"/>
         <release version="2.8.0" date="2019-01-29"/>
     </releases>
 

--- a/io.github.cmus.cmus.yml
+++ b/io.github.cmus.cmus.yml
@@ -141,8 +141,8 @@ modules:
       - install -Dm644 io.github.cmus.cmus.metainfo.xml /app/share/appdata/${FLATPAK_ID}.appdata.xml
     sources:
       - type: archive
-        url: https://github.com/cmus/cmus/archive/v2.8.0.tar.gz
-        sha512: cf359dfcefa833a5b10a2d16ac405672bea762b62b7177c115560127035682fba65c15b9a8710179a343d1f99212a0260b5c095542982202e2cd1bef5b0c17fc
+        url: https://github.com/cmus/cmus/archive/v2.9.1.tar.gz
+        sha512: b417e58a68c54e97db92b8760a49a3071e81f1594f2144911eed3ccceb68499dedf0699ae313babcb822d71b37add8880dfb2018686cb572e89f8627446d5e05
       - type: patch
         path: configure.patch
       - type: file


### PR DESCRIPTION
Still can't update mp4v2 yet, although cmus/cmus#1078 should fix that eventually.