### PR TITLE
Patch musepack properly instead of using compiler flags

### DIFF
--- a/io.github.cmus.cmus.yml
+++ b/io.github.cmus.cmus.yml
@@ -61,18 +61,18 @@ modules:
         url: https://download.sourceforge.net/project/modplug-xmms/libmodplug/0.8.9.0/libmodplug-0.8.9.0.tar.gz
         sha512: 880e10154fd367ee24ace53ca7e32a5c1fee7dfff1f934e6499944c12779427da63e2f55f8d6ce25db0a42a5b4424053bf64305b31dbfc4ef6a8909924d655fd
 
-  # Instruction taken from org.freac.freac.json
+  # Instruction taken from org.freac.freac.json except for the patch
   - name: musepack
     buildsystem: autotools
     cleanup:
       - /include
       - /bin
-    config-opts:
-      - LDFLAGS=-Wl,--allow-multiple-definition
     sources:
       - type: archive
         url: https://files.musepack.net/source/musepack_src_r475.tar.gz
         sha256: a4b1742f997f83e1056142d556a8c20845ba764b70365ff9ccf2e3f81c427b2b
+      - type: patch
+        path: musepack-missing-extern.patch
       - type: shell
         commands: 
           - touch include/config.h.in

--- a/musepack-missing-extern.patch
+++ b/musepack-missing-extern.patch
@@ -1,0 +1,22 @@
+Subject: Add extern keyword to global variable declaration.
+Origin: upstream, commit:r479
+Bug-Debian: http://bugs.debian.org/665974
+---
+ libmpcdec/requant.h |    6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- libmpc.orig/libmpcdec/requant.h
++++ libmpc/libmpcdec/requant.h
+@@ -47,9 +47,9 @@ extern "C" {
+ 
+ 
+ /* C O N S T A N T S */
+-const mpc_uint8_t      Res_bit [18];     ///< Bits per sample for chosen quantizer
+-const MPC_SAMPLE_FORMAT __Cc    [1 + 18]; ///< Requantization coefficients
+-const mpc_int16_t       __Dc    [1 + 18]; ///< Requantization offset
++extern const mpc_uint8_t      Res_bit [18];     ///< Bits per sample for chosen quantizer
++extern const MPC_SAMPLE_FORMAT __Cc    [1 + 18]; ///< Requantization coefficients
++extern const mpc_int16_t       __Dc    [1 + 18]; ///< Requantization offset
+ 
+ #define Cc (__Cc + 1)
+ #define Dc (__Dc + 1)


### PR DESCRIPTION
Now playback of musepack files should work properly, the patch is used by Arch Linux as well.

Fixes #6.